### PR TITLE
Introduce InferredInputType to replace getValidInputType

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,19 +70,17 @@ And the document that will be stored in the database
 
 ```json
 {
-    "id": "63344e08508c95326902ff9b",
+    "id": "63393dd4acc4d97a2c71f3bf",
     "name": "hello",
     "nationality": {
         "value": "SINGAPOREAN",
-        "inputType": "SELECTION",
         "selectionValue": "SINGAPOREAN",
-        "validInputType": true
+        "inputType": "SELECTION"
     },
     "placeOfBirth": {
-        "value": "SINGAPORE",
-        "inputType": "SELECTION",
-        "selectionValue": "SINGAPORE",
-        "validInputType": true
+        "value": "SINGAPO1RE",
+        "selectionValue": "OTHERS",
+        "inputType": "FREETEXT"
     },
     "father": {
         "value": "633421fb64082a7561f90bd0",
@@ -122,9 +120,8 @@ Given that `nationality` accepts only `SINGAPOREAN and MALAYSIAN`, it can be onl
     "name": "hello",
     "nationality": {
         "value": "SINGAPOREAN",
-        "inputType": "SELECTION",
         "selectionValue": "SINGAPOREAN",
-        "validInputType": true
+        "inputType": "SELECTION"
     }
 }
 ```
@@ -164,9 +161,8 @@ Given that `placeOfBirth` accepts only `SINGAPORE, MALAYSIA and OTHERS`, we can 
     "name": "hello",
     "placeOfBirth": {
         "value": "SINGAPORE",
-        "inputType": "SELECTION",
         "selectionValue": "SINGAPORE",
-        "validInputType": true
+        "inputType": "SELECTION"
     }
 }
 ```
@@ -185,9 +181,8 @@ Given that `placeOfBirth` accepts only `SINGAPORE, MALAYSIA and OTHERS`, we can 
     "name": "hello",
     "placeOfBirth": {
         "value": "SOMETHING ELSE",
-        "inputType": "FREETEXT",
         "selectionValue": "OTHERS",
-        "validInputType": true
+        "inputType": "FREETEXT"
     }
 }
 ```
@@ -209,14 +204,15 @@ Do we take in `OTHERS` as a valid input? Or it should throw an `BAD_REQUEST`? Be
     "name": "hello",
     "placeOfBirth": {
         "value": "OTHERS",
-        "inputType": "SELECTION",
         "selectionValue": "OTHERS",
-        "validInputType": true
+        "inputType": "SELECTION"
     }
 }
 ```
 
 ## Reference
+
+`Selection` and `Reference` have to be treated differently hence the interface will be slightly different as a result. For `Selection` type, we can have the `enum class` to implements `UserInput` such that it will be controlled using `enum` and override when needed. But, for `Reference` type, unless we have a way to let each of the `ReferenceEntity` to implement and return the `InputType` value, it would not be feasible
 
 ### First Attempt
 
@@ -350,15 +346,13 @@ record PersonDTO(String name, String nationality, String placeOfBirth, String fa
     "name": "hello",
     "nationality": {
         "value": "SINGAPOREAN",
-        "inputType": "SELECTION",
         "selectionValue": "SINGAPOREAN",
-        "validInputType": true
+        "inputType": "SELECTION"
     },
     "placeOfBirth": {
         "value": "SINGAPORE",
-        "inputType": "SELECTION",
         "selectionValue": "SINGAPORE",
-        "validInputType": true
+        "inputType": "SELECTION"
     },
     "father": {
         "value": "633421fb64082a7561f90bd0",
@@ -408,6 +402,20 @@ As shown above, the output is exactly the same as the previously method. Note th
 
 At the minimum, it should works as a `checksum`
 
+**Based on current PR proposal, this field will no longer exist, and the responsibility to declare the correct `inputType` lies on the respective implementing class
+
 - Is there any reason to have both `Reference` and `ReferenceFreeText`? Will it always just be `ReferenceFreeText` only? We should provide it nonetheless?
+  - There will be use-case where this is valid, hence, both should be supported
+
+- Would it be useful to expose two different API response using `@JsonView` for `service-call` and `consumer-call`?
+
+- What would the worst case scenario when the `enum` does not get updated as it changes (i.e not in sync with the values from source or database)
+  - Not in sync with source; source updated but enum not reflected, to clarify, source could be as simple as client and server list
+    - This would have to depends on the `InputType` where `Selection` would have issue, but not `SelectionFreeText` as it could be just casted to `OTHERS`
+  - Not in sync with database; enum updated but there are old documents referring to old enum value
+    - Generally, when the enum value change, migration script would have to be written to handle for that conversion as well
+
+- Technically, I could combine both `Selection` and `SelectionFreeText` into one, what should the one to be removed if decided to? Or is there any reason I can't do so?
+
 
 - Would it be useful to expose two different API response using `@JsonView` for `service-call` and `consumer-call`?

--- a/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/PersonDTOtoPersonConverter.java
+++ b/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/PersonDTOtoPersonConverter.java
@@ -26,8 +26,8 @@ public class PersonDTOtoPersonConverter implements Converter<PersonDTO, Person> 
     public Person convert(PersonDTO personDTO) {
         return Person.builder()
             .name(personDTO.name())
-            .nationality(new NationalityUserInput(personDTO.nationality()))
-            .placeOfBirth(new PlaceOfBirthUserInput(personDTO.placeOfBirth()))
+            .nationality(NationalityUserInput.of(personDTO.nationality()))
+            .placeOfBirth(PlaceOfBirthUserInput.of(personDTO.placeOfBirth()))
             .father(this.initFather(personDTO.father()))
             .mother(this.initMother(personDTO.mother()))
             .build();

--- a/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/domain/Country.java
+++ b/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/domain/Country.java
@@ -1,7 +1,23 @@
 package com.bwgjoseph.springmvcdynamicuserinput.domain;
 
-public enum Country {
+import com.bwgjoseph.springmvcdynamicuserinput.userinput.InferredInputType;
+import com.bwgjoseph.springmvcdynamicuserinput.userinput.InputType;
+
+/**
+ * Selection + FreeText
+ */
+public enum Country implements InferredInputType {
     SINGAPORE,
     MALAYSIA,
-    OTHERS
+    OTHERS {
+        @Override
+        public InputType getInferredInputType() {
+            return InputType.FREETEXT;
+        }
+    };
+
+    @Override
+    public InputType getInferredInputType() {
+        return InputType.SELECTION;
+    }
 }

--- a/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/domain/Nationality.java
+++ b/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/domain/Nationality.java
@@ -1,6 +1,27 @@
 package com.bwgjoseph.springmvcdynamicuserinput.domain;
 
-public enum Nationality {
-    SINGAPOREAN,
-    MALAYSIAN
+import com.bwgjoseph.springmvcdynamicuserinput.userinput.InferredInputType;
+import com.bwgjoseph.springmvcdynamicuserinput.userinput.InputType;
+
+/**
+ * Selection ONLY
+ */
+public enum Nationality implements InferredInputType {
+    SINGAPOREAN("Singaporean"),
+    MALAYSIAN("Malaysian");
+
+    private String value;
+
+    Nationality(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+    @Override
+    public InputType getInferredInputType() {
+        return InputType.SELECTION;
+    }
 }

--- a/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/domain/NationalityUserInput.java
+++ b/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/domain/NationalityUserInput.java
@@ -1,5 +1,7 @@
 package com.bwgjoseph.springmvcdynamicuserinput.domain;
 
+import org.springframework.data.mongodb.core.mapping.Field;
+
 import com.bwgjoseph.springmvcdynamicuserinput.userinput.InputType;
 import com.bwgjoseph.springmvcdynamicuserinput.userinput.Selection;
 
@@ -14,25 +16,35 @@ public class NationalityUserInput implements Selection<Nationality> {
      */
     private String value;
     /**
-     * Stores the selection value
+     * Map to the respective Enum based on the input value
      */
+    @Field("selectionValue")
     private Nationality nationality;
     /**
-     * InputType is inferred based on the value
-     * *may not work for reference since it requires external call to validate
-     *
-     * How to ensure the inputType is within the constraint of `getValidInputType`?
+     * This value should be inferred based on the input
      */
     private InputType inputType;
 
     /**
+     * Private constructor that only called by static method
      *
-     * @param input
+     * @param inputValue actual input value
+     * @param nationality actual enum value
      */
-    public NationalityUserInput(String input) {
-        this.nationality = Nationality.valueOf(input);
-        this.inputType = InputType.SELECTION;
-        this.value = input;
+    NationalityUserInput(String inputValue, Nationality nationality) {
+        this.value = inputValue;
+        this.nationality = nationality;
+        this.inputType = nationality.getInferredInputType();
+    }
+
+    /**
+     * Expose static method to init the class
+     *
+     * @param inputValue actual input value
+     * @return NationalityUserInput instance
+     */
+    public static NationalityUserInput of(String inputValue) {
+        return new NationalityUserInput(inputValue, Nationality.valueOf(inputValue));
     }
 
     @Override
@@ -41,12 +53,12 @@ public class NationalityUserInput implements Selection<Nationality> {
     }
 
     @Override
-    public Nationality getSelectionValue() {
-        return this.nationality;
+    public InputType getInputType() {
+        return this.inputType;
     }
 
     @Override
-    public InputType getInputType() {
-        return this.inputType;
+    public Nationality getSelectionValue() {
+        return this.nationality;
     }
 }

--- a/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/domain/NationalityUserInput.java
+++ b/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/domain/NationalityUserInput.java
@@ -1,7 +1,5 @@
 package com.bwgjoseph.springmvcdynamicuserinput.domain;
 
-import org.springframework.data.mongodb.core.mapping.Field;
-
 import com.bwgjoseph.springmvcdynamicuserinput.userinput.InputType;
 import com.bwgjoseph.springmvcdynamicuserinput.userinput.Selection;
 
@@ -18,8 +16,7 @@ public class NationalityUserInput implements Selection<Nationality> {
     /**
      * Map to the respective Enum based on the input value
      */
-    @Field("selectionValue")
-    private Nationality nationality;
+    private Nationality selectionValue;
     /**
      * This value should be inferred based on the input
      */
@@ -33,7 +30,7 @@ public class NationalityUserInput implements Selection<Nationality> {
      */
     NationalityUserInput(String inputValue, Nationality nationality) {
         this.value = inputValue;
-        this.nationality = nationality;
+        this.selectionValue = nationality;
         this.inputType = nationality.getInferredInputType();
     }
 
@@ -59,6 +56,6 @@ public class NationalityUserInput implements Selection<Nationality> {
 
     @Override
     public Nationality getSelectionValue() {
-        return this.nationality;
+        return this.selectionValue;
     }
 }

--- a/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/domain/PlaceOfBirthUserInput.java
+++ b/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/domain/PlaceOfBirthUserInput.java
@@ -1,5 +1,7 @@
 package com.bwgjoseph.springmvcdynamicuserinput.domain;
 
+import org.springframework.data.mongodb.core.mapping.Field;
+
 import com.bwgjoseph.springmvcdynamicuserinput.userinput.InputType;
 import com.bwgjoseph.springmvcdynamicuserinput.userinput.SelectionFreeText;
 
@@ -16,6 +18,7 @@ public class PlaceOfBirthUserInput implements SelectionFreeText<Country> {
     /**
      * Stores the selection value
      */
+    @Field("selectionValue")
     private Country country;
     /**
      * InputType is inferred based on the value
@@ -24,6 +27,14 @@ public class PlaceOfBirthUserInput implements SelectionFreeText<Country> {
      * How to ensure the inputType is within the constraint of `getValidInputType`?
      */
     private InputType inputType;
+
+    public static PlaceOfBirthUserInput of(String inputValue) {
+        try {
+            return new PlaceOfBirthUserInput(inputValue, Country.valueOf(inputValue));
+        } catch (IllegalArgumentException e) {
+            return new PlaceOfBirthUserInput(inputValue, Country.valueOf("OTHERS"));
+        }
+    }
 
     /**
      * Client should not pass `OTHERS` if it is selected, instead, they should pass the `freetext` value
@@ -35,17 +46,10 @@ public class PlaceOfBirthUserInput implements SelectionFreeText<Country> {
      *
      * @param input input value
      */
-    public PlaceOfBirthUserInput(String input) {
+    public PlaceOfBirthUserInput(String input, Country country) {
         this.value = input;
-        // if we can't cast it to the enum we expect,
-        // then we can infer that this is a `freetext` rather than a `selection`
-        try {
-            this.country = Country.valueOf(input);
-            this.inputType = InputType.SELECTION;
-        } catch (IllegalArgumentException e) {
-            this.country = Country.valueOf("OTHERS");
-            this.inputType = InputType.FREETEXT;
-        }
+        this.country = country;
+        this.inputType = country.getInferredInputType();
     }
 
     @Override

--- a/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/domain/PlaceOfBirthUserInput.java
+++ b/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/domain/PlaceOfBirthUserInput.java
@@ -1,7 +1,5 @@
 package com.bwgjoseph.springmvcdynamicuserinput.domain;
 
-import org.springframework.data.mongodb.core.mapping.Field;
-
 import com.bwgjoseph.springmvcdynamicuserinput.userinput.InputType;
 import com.bwgjoseph.springmvcdynamicuserinput.userinput.SelectionFreeText;
 
@@ -18,8 +16,7 @@ public class PlaceOfBirthUserInput implements SelectionFreeText<Country> {
     /**
      * Stores the selection value
      */
-    @Field("selectionValue")
-    private Country country;
+    private Country selectionValue;
     /**
      * InputType is inferred based on the value
      * *may not work for reference since it requires external call to validate
@@ -48,7 +45,7 @@ public class PlaceOfBirthUserInput implements SelectionFreeText<Country> {
      */
     public PlaceOfBirthUserInput(String input, Country country) {
         this.value = input;
-        this.country = country;
+        this.selectionValue = country;
         this.inputType = country.getInferredInputType();
     }
 
@@ -64,7 +61,7 @@ public class PlaceOfBirthUserInput implements SelectionFreeText<Country> {
 
     @Override
     public Country getSelectionValue() {
-        return this.country;
+        return this.selectionValue;
     }
 
 }

--- a/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/userinput/InferredInputType.java
+++ b/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/userinput/InferredInputType.java
@@ -1,0 +1,10 @@
+package com.bwgjoseph.springmvcdynamicuserinput.userinput;
+
+/**
+ * Implementing class must declare the correct InputType
+ * <p>
+ * For Selection/SelectionFreeText, it should be implemented in the `enum` class
+ */
+public interface InferredInputType {
+    InputType getInferredInputType();
+}

--- a/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/userinput/Selection.java
+++ b/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/userinput/Selection.java
@@ -2,8 +2,4 @@ package com.bwgjoseph.springmvcdynamicuserinput.userinput;
 
 public interface Selection<T extends Enum<T>> extends UserInput {
     T getSelectionValue();
-
-    default boolean getValidInputType() {
-        return this.getInputType().equals(InputType.SELECTION);
-    }
 }

--- a/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/userinput/SelectionFreeText.java
+++ b/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/userinput/SelectionFreeText.java
@@ -2,10 +2,4 @@ package com.bwgjoseph.springmvcdynamicuserinput.userinput;
 
 public interface SelectionFreeText<T extends Enum<T>> extends UserInput {
     T getSelectionValue();
-
-    // how can we use this to restrict/validate each implementing class
-    // to not violate the acceptable inputType?
-    default boolean getValidInputType() {
-        return this.getInputType().equals(InputType.SELECTION) || this.getInputType().equals(InputType.FREETEXT);
-    }
 }

--- a/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/userinput/UserInput.java
+++ b/src/main/java/com/bwgjoseph/springmvcdynamicuserinput/userinput/UserInput.java
@@ -1,6 +1,6 @@
 package com.bwgjoseph.springmvcdynamicuserinput.userinput;
 
 public interface UserInput {
-    InputType getInputType();
     String getValue();
+    InputType getInputType();
 }

--- a/src/test/java/com/bwgjoseph/springmvcdynamicuserinput/NationalityUserInputTests.java
+++ b/src/test/java/com/bwgjoseph/springmvcdynamicuserinput/NationalityUserInputTests.java
@@ -12,17 +12,16 @@ class NationalityUserInputTests {
 
     @Test
     void givenNationalityAsSingaporean_shouldSetInputTypeAsSelection() {
-        this.cut = new NationalityUserInput("SINGAPOREAN");
+        this.cut = NationalityUserInput.of("SINGAPOREAN");
 
         Assertions.assertThat(this.cut.getValue()).isEqualTo("SINGAPOREAN");
         Assertions.assertThat(this.cut.getSelectionValue()).isEqualTo(Nationality.SINGAPOREAN);
         Assertions.assertThat(this.cut.getInputType()).isEqualTo(InputType.SELECTION);
-        Assertions.assertThat(this.cut.getValidInputType()).isTrue();
     }
 
     @Test
     void givenNationalityAsSomethingElse_shouldThrowException() {
-        Assertions.assertThatThrownBy(() -> new NationalityUserInput("SOMETHING ELSE"))
+        Assertions.assertThatThrownBy(() -> NationalityUserInput.of("SOMETHING ELSE"))
             .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/com/bwgjoseph/springmvcdynamicuserinput/PlaceOfBirthUserInputTests.java
+++ b/src/test/java/com/bwgjoseph/springmvcdynamicuserinput/PlaceOfBirthUserInputTests.java
@@ -12,21 +12,19 @@ public class PlaceOfBirthUserInputTests {
 
     @Test
     void givenPobAsSingapore_shouldSetInputTypeAsSelection() {
-        this.cut = new PlaceOfBirthUserInput("SINGAPORE");
+        this.cut = PlaceOfBirthUserInput.of("SINGAPORE");
 
         Assertions.assertThat(this.cut.getValue()).isEqualTo("SINGAPORE");
         Assertions.assertThat(this.cut.getSelectionValue()).isEqualTo(Country.SINGAPORE);
         Assertions.assertThat(this.cut.getInputType()).isEqualTo(InputType.SELECTION);
-        Assertions.assertThat(this.cut.getValidInputType()).isTrue();
     }
 
     @Test
     void givenPobAsSomethingElse_shouldSetInputTypeAsFreeText() {
-        this.cut = new PlaceOfBirthUserInput("SOMETHING ELSE");
+        this.cut = PlaceOfBirthUserInput.of("SOMETHING ELSE");
 
         Assertions.assertThat(this.cut.getValue()).isEqualTo("SOMETHING ELSE");
         Assertions.assertThat(this.cut.getSelectionValue()).isEqualTo(Country.OTHERS);
         Assertions.assertThat(this.cut.getInputType()).isEqualTo(InputType.FREETEXT);
-        Assertions.assertThat(this.cut.getValidInputType()).isTrue();
     }
 }


### PR DESCRIPTION
This PR introduced `InferredInputType` interface with single abstract method `getInferredInputType` to replace `getValidInputType` that used to be declared within `UserInput` subclass (interfaces)

As such, it allows for the class that would be best to identify the `inputType` to implement `InferredInputType` interface. For example, in the class for `Selection and SelectionFreeText` can be implemented directly within the `enum` class

```java
public enum Nationality implements InferredInputType {
    SINGAPOREAN("Singaporean"),
    MALAYSIAN("Malaysian");

    @Override
    public InputType getInferredInputType() {
        return InputType.SELECTION;
    }
}

public enum Country implements InferredInputType {
    SINGAPORE,
    MALAYSIA,
    OTHERS {
        @Override
        public InputType getInferredInputType() {
            return InputType.FREETEXT;
        }
    };

    @Override
    public InputType getInferredInputType() {
        return InputType.SELECTION;
    }
}
```

The source class should be the class that implements InferredInputType where source class refer to the class that will be able to best determine the InputType. For example, for the case of Selection based input, the enum class should be the one to dictate it.

In addition, I also introduce a static method to init the class instead of using constructor. This should allow me to hide additional logic by using the static method before calling the constructor. This also solved one of my worries where I had to perform additional logic within the constructor.